### PR TITLE
Update modal test

### DIFF
--- a/front-end/src/components/__tests__/Modal.test.js
+++ b/front-end/src/components/__tests__/Modal.test.js
@@ -1,7 +1,11 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ModalDesconected from '../modals/modal-desconected';
 
 test('Renderiza modal', () => {
-  render(<ModalDesconected isOpen={false} />);
+  const mockFn = jest.fn();
+  render(<ModalDesconected isOpen={true} onConfirm={mockFn} />);
+  expect(screen.getByText('Sessão Expirada')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /ok/i }));
+  expect(mockFn).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- improve ModalDesconected test to open modal and confirm action

## Testing
- `npm --prefix front-end test`

------
https://chatgpt.com/codex/tasks/task_e_6841f0fbd9c8833292534580aa08392c