### PR TITLE
Fix README path instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,21 +43,26 @@ O projeto será desenvolvido utilizando as seguintes tecnologias:
 
 ### 🚀 Clonar o Repositório
 
-bash
+```bash
 git clone https://github.com/jaooduartte/atleticaengenios.git
 cd atleticaengenios
+```
 
 ### ⚙️ Configuração do Front-end
 
-cd frontend
+```bash
+cd front-end
 npm install
 npm run dev
+```
 
 ### 🔧 Configuração do Back-end
 
-cd backend
+```bash
+cd back-end
 npm install
 npm start
+```
 
 ### ✉️ Contato
 


### PR DESCRIPTION
## Summary
- fix installation instructions to match `front-end` and `back-end` dirs
- format setup commands with bash code blocks

## Testing
- `cd back-end && npm test --silent` *(fails: jest not found)*
- `cd front-end && npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f0e5bd248332baf46f8fd51e0d43