### PR TITLE
Fix token parsing in auth hook

### DIFF
--- a/front-end/src/hooks/useAuth.js
+++ b/front-end/src/hooks/useAuth.js
@@ -10,7 +10,15 @@ export default function useAuth() {
       if (!token) return;
 
       try {
-        const decoded = jwtDecode(token);
+        let decoded;
+        try {
+          decoded = jwtDecode(token);
+        } catch (decodeErr) {
+          console.error('Token inválido:', decodeErr);
+          localStorage.removeItem('token');
+          return;
+        }
+
         if (decoded.exp * 1000 < Date.now()) {
           localStorage.removeItem('token');
           return;
@@ -19,11 +27,9 @@ export default function useAuth() {
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/me`, {
           headers: { Authorization: `Bearer ${token}` },
         });
-        
 
         if (res.ok) {
-          const text = await res.text();
-          const data = JSON.parse(text);
+          const data = await res.json();
           setUser({
             id: Number(data.user?.id),
             name: data.user?.name || 'Usuário',


### PR DESCRIPTION
## Summary
- improve error handling for invalid JWT tokens
- avoid text parsing in `useAuth` by using `res.json()`

## Testing
- `npm test --prefix front-end -- --passWithNoTests`
- `npm test --prefix back-end -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6841eb08e8508332bbeaafb2ba14bbc4