### PR TITLE
Fix session check for password reset

### DIFF
--- a/front-end/src/pages/_app.js
+++ b/front-end/src/pages/_app.js
@@ -16,7 +16,8 @@ export default function App({ Component, pageProps }) {
 
   useEffect(() => {
     const publicRoutes = ['/login', '/confirm', '/forgot-password', '/reset-password'];
-    if (publicRoutes.includes(router.pathname)) return;
+    const currentPath = router.asPath.split(/[?#]/)[0];
+    if (publicRoutes.includes(currentPath) || publicRoutes.includes(router.pathname)) return;
 
     const checkToken = async () => {
       const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- ignore session validation on reset password links

## Testing
- `npm --prefix front-end test -- --passWithNoTests`
- `npm --prefix back-end test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6850b9313af483329ce83f0866b2f37b